### PR TITLE
NO-JIRA: Added overflow to <pre> styles

### DIFF
--- a/skins/floe/main.css
+++ b/skins/floe/main.css
@@ -458,6 +458,7 @@ textarea {
 pre {
   margin: 2em;
   border: solid 1px black;
+  overflow: auto;
 }
 
 


### PR DESCRIPTION
@acheetham A quick fix to make the <pre> blocks overflow nicely on low resolution or small windows.
